### PR TITLE
Add agent-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Everything that checks or constrains what the agent did — before, during and a
 - **[tuicr](https://github.com/agavra/tuicr)** — the human half of the loop: a terminal code reviewer with vim bindings, line-level comments, per-file/hunk seen-tracking across sessions, and export to GitHub/GitLab. Reviews uncommitted changes — exactly the diff your agent just produced.
 - **[dcg](https://github.com/Dicklesworthstone/destructive_command_guard)** — blocks destructive git and shell commands before the agent executes them; a guard layer over any CLI agent.
 - **[Mindwalk](https://github.com/cosmtrek/mindwalk)** — replays an agent session on a 3D map of the codebase: where it walked, what it touched.
+- **[agent-qa](https://github.com/vostride/agent-qa)** — turns the application check after an agent's diff into a reusable web and mobile regression loop: natural-language tests, persistent test memory, self-healing flows and evidence through a dashboard, CLI and MCP.
 
 ## Security: pentest, reverse engineering and audit
 


### PR DESCRIPTION
Adds [agent-qa](https://github.com/vostride/agent-qa) under Review, guardrails and forensics.

agent-qa turns the application check after an agent's diff into a reusable web and mobile regression loop: natural-language tests, persistent test memory, self-healing flows, and evidence through its dashboard, CLI, and MCP server.

What changes at the keyboard: instead of asking a coding agent to perform one-off browser checks after every change, a developer can give it durable regression flows through the bundled MCP server and Agent Skills, then inspect the run artifacts and triage failures.

The repository currently has 786 stars. I am project-affiliated and have not independently run it as an outside reviewer; the entry and capability details were checked against the public source and documentation. The current FSL-1.1-ALv2 release is source-available and converts to Apache-2.0 after two years.
