### PR TITLE
Add SandBase Harness to harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Layers over the agent CLI: a UI, a workspace, or a bundle of capabilities.
 - **[ECC](https://github.com/affaan-m/ECC)** — an installable capability layer over Claude Code / Codex / Opencode / Cursor: skills, instincts, memory, security and a research-first process.
 - **[jcode](https://github.com/1jehuang/jcode)** — a deliberately minimal harness, tuned for low RAM against the GUI-heavy alternatives.
 - **[claude-code-templates](https://github.com/davila7/claude-code-templates)** — CLI for configuring and monitoring Claude Code: agent, command and hook templates.
+- **[sandbase-harness](https://github.com/sandbaseai/sandbase-harness)** — local-first runtime for durable agent sessions with sandboxed tools, MCP access, approvals, credentials, audit, and replay.
 
 ## Coding agent CLIs
 


### PR DESCRIPTION
Add SandBase Harness to the Harnesses, GUIs and workspaces section.

- What it does: local-first runtime for durable agent sessions with sandboxed tools, MCP access, approvals, credentials, audit, and replay.
- What changes at the keyboard: developers can run governed, resumable agent tool work instead of treating each invocation as a one-shot process.
- Current stars: 640.
- I have not independently run the full runtime in this environment; the entry is based on the repository documentation and source-linked installation/MCP guides.
- This is a maintainer-affiliated submission; isolation depends on backend and deployment configuration, and no directory endorsement or security certification is claimed.